### PR TITLE
Use User transform methods instead of interal shape's

### DIFF
--- a/inc/User.hpp
+++ b/inc/User.hpp
@@ -5,6 +5,7 @@
 #define USER_hpp
 
 #include "Game.hpp"
+#include "SFML/Graphics/Rect.hpp"
 #include "SFML/System/Vector2.hpp"
 #include "SFML/Graphics/Texture.hpp"
 #include "SFML/Graphics/Sprite.hpp"
@@ -13,9 +14,9 @@ class User : public sf::Drawable, public sf::Transformable {
 public:
     User();
 
-    sf::RectangleShape & getShape() ; //do not return const ref. due to move() call in Game.cpp
-
-    void setPlatformPos(float x, float y);
+    const sf::FloatRect getGlobalBounds() const {
+        return getTransform().transformRect(platform.getGlobalBounds());
+    }
 
 private:
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -87,15 +87,15 @@ void Game::eventManager(){
                 switch (event.key.scancode) {
 
                     case sf::Keyboard::Scan::Down:
-                        if(player.getShape().getPosition().y + 20 < minHeight)
-                            player.getShape().move(0,20);
-                        std::cout << player.getShape().getPosition().y << std::endl;
+                        if(player.getPosition().y + 20 < minHeight)
+                            player.move(0,20);
+                        std::cout << player.getPosition().y << std::endl;
                         break;
 
                     case sf::Keyboard::Scan::Up:
-                        if(player.getShape().getPosition().y - 20 > maxHeight)
-                            player.getShape().move(0, -20);
-                        std::cout << player.getShape().getPosition().y << std::endl;
+                        if(player.getPosition().y - 20 > maxHeight)
+                            player.move(0, -20);
+                        std::cout << player.getPosition().y << std::endl;
                         break;
 
                     default:
@@ -119,7 +119,7 @@ void Game::run(){
 }
 
 void Game::hit(){  // remember that the y-axis is flipped, down is positive and up negative. x-axis is OK
-    if(ball.getShape().getGlobalBounds().intersects(player.getShape().getGlobalBounds())){
+    if(ball.getShape().getGlobalBounds().intersects(player.getGlobalBounds())){
         ball.setVelocity(ball.getVelocity().x * (-1), ball.getVelocity().y * (1));
         score++;
     }

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -4,14 +4,8 @@
 #include "Game.hpp"
 
 User::User() : platform(sf::Vector2f(5.f, 100.f)) {
-
-    platform.setOrigin(0.f,50.f);
-    platform.setPosition(150.f, 300.f);
+    setOrigin(0.f,50.f);
+    setPosition(150.f, 300.f);
     platform.setFillColor(sf::Color::Green);
-
 }
-
-sf::RectangleShape& User::getShape() { return platform; }
-
-void User::setPlatformPos(float x, float y) { this->setPosition(x, y); }
 


### PR DESCRIPTION
Due to the incapsulation principle, the end user shouldn't care about the internal representation of the User.

This commits leverages the sf::Transformable base class of User to apply transformations to the inner shape.